### PR TITLE
Add instructions for installing bash on Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,10 @@
 # Installing the required software
 
 
-
 > 🚨 **IMPORTANT NOTE** 🚨
 > Installing GMT and its dependencies can be a difficult task even for experienced
 > users (including the developers themselves). So **don't be discouraged** if you
 > have any trouble or questions. [We're here to help you work through it!](#need-help)
-
 
 
 Please follow these instructions to install **GMT 6.0.0rc2** (rc = release candidate)
@@ -116,6 +114,8 @@ Make sure you also [have a text editor installed](#install-a-text-editor).
 
 Before installing GMT, you will need access to a UNIX style terminal with a
 [bash shell](https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29) for GMT scripting.
+**Don't worry if you don't know what this means. We'll go through it in the first day of
+the workshop.**
 Linux and Mac usually come with one installed but Windows users aren't so lucky.
 To install a terminal with a bash shell on Windows:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -114,6 +114,18 @@ Make sure you also [have a text editor installed](#install-a-text-editor).
 
 ## Windows
 
+Before installing GMT, you will need access to a UNIX style terminal with a
+[bash shell](https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29) for GMT scripting.
+Linux and Mac usually come with one installed but Windows users aren't so lucky.
+To install a terminal with a bash shell on Windows:
+
+1. Download and install Git-for-Windows `Git-2.22.0-64-bit.exe` from
+   [their official website](https://gitforwindows.org/).
+   There are
+   [video instructions for installing](https://www.youtube.com/watch?v=339AEqk9c-8)
+   provided by [Software Carpentry](https://software-carpentry.org/)
+2. In this course, when you see/hear "Terminal" you should open the "Git Bash" program.
+
 There are 3 options for installing GMT 6.0.0rc2 on Windows:
 
 1. Use the GMT Windows installer and install Ghostscript and ffmpeg separately


### PR DESCRIPTION
Use https://gitforwindows.org and instructions by Software Carpentry.