### PR TITLE
Add the Dropbox link for Windows installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,7 +132,8 @@ To install GMT, we'll use the Windows installer:
 1. Download and install Ghostscript `gs926aw64.exe`
    [from the official website](https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/tag/gs926)
 2. Download and install the GMT Windows installer `gmt-6.0.0_2019.07.10-win64.exe`
-   from [this link](http://w3.ualg.pt/~jluis/mirone/gmt-6.0.0_2019.07.10-win64.exe).
+   from [this link](http://w3.ualg.pt/~jluis/mirone/gmt-6.0.0_2019.07.10-win64.exe)
+   or [the Dropbox link](https://www.dropbox.com/s/psc3hh3442qt8b9/gmt-6.0.0_2019.07.10-win64.exe?dl=0).
    It comes with GDAL and ffmpeg pre installed.
 
 Make sure you also [have a text editor installed](#install-a-text-editor).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,7 +133,7 @@ To install GMT, we'll use the Windows installer:
    [from the official website](https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/tag/gs926)
 2. Download and install the GMT Windows installer `gmt-6.0.0_2019.07.10-win64.exe`
    from [this link](http://w3.ualg.pt/~jluis/mirone/gmt-6.0.0_2019.07.10-win64.exe)
-   or [the Dropbox link](https://www.dropbox.com/s/psc3hh3442qt8b9/gmt-6.0.0_2019.07.10-win64.exe?dl=0).
+   or [the faster Dropbox link](https://www.dropbox.com/s/psc3hh3442qt8b9/gmt-6.0.0_2019.07.10-win64.exe?dl=1).
    It comes with GDAL and ffmpeg pre installed.
 
 Make sure you also [have a text editor installed](#install-a-text-editor).


### PR DESCRIPTION
The Dropbox link is much faster for US-based participants.